### PR TITLE
Add hotfix for houses retrieval data

### DIFF
--- a/app/house.py
+++ b/app/house.py
@@ -151,14 +151,22 @@ def specific_email(house_id, identifier):
 @house_blueprint.route("/user")
 @jwt_required
 def all_user_houses():
-    user = get_jwt_identity()
-    db_user: User = User.query.get(user)
+    user = User.query.get(get_jwt_identity())
     return jsonify(
-        {
-            "data": list(map(lambda x: x.id, db_user.houses)),
-            "msg": "",
-            "status": "success",
-        }
+        msg="",
+        status="success",
+        data=list(
+            map(
+                lambda x: {
+                    "house_id": x.id,
+                    "name": x.name,
+                    "description": x.description,
+                    "tasks": x.tasks,
+                    "users": x.users,
+                },
+                user.houses,
+            )
+        ),
     )
 
 

--- a/app/house.py
+++ b/app/house.py
@@ -161,8 +161,6 @@ def all_user_houses():
                     "house_id": x.id,
                     "name": x.name,
                     "description": x.description,
-                    "tasks": x.tasks,
-                    "users": x.users,
                 },
                 user.houses,
             )

--- a/app/test_e2e.py
+++ b/app/test_e2e.py
@@ -212,7 +212,7 @@ def test_user_get_task_by_id(client: Client):
     auth = authenticate_user1(client)
     resp = client.get("/house/user", headers={"Authorization": auth})
     json_resp = resp.get_json()
-    house_1 = json_resp["data"][0]
+    house_1 = json_resp["data"][0]["house_id"]
     get_tasks_resp = client.get(
         "/house/{}/task/all".format(house_1), headers={"Authorization": auth}
     ).get_json()

--- a/app/test_e2e.py
+++ b/app/test_e2e.py
@@ -31,7 +31,7 @@ TASK1_FREQUENCY = 3600
 def get_house1_id(client, auth):
     resp = client.get("/house/user", headers={"Authorization": auth})
     json_resp = resp.get_json()
-    return json_resp["data"][0]
+    return json_resp["data"][0]["house_id"]
 
 
 @pytest.fixture
@@ -227,9 +227,7 @@ def test_user_get_task_by_id(client: Client):
 @pytest.mark.serial
 def test_user_update_task(client: Client):
     auth = authenticate_user1(client)
-    resp = client.get("/house/user", headers={"Authorization": auth})
-    json_resp = resp.get_json()
-    house_1 = json_resp["data"][0]
+    house_1 = get_house1_id(client, auth)
     get_tasks_resp = client.get(
         "/house/{}/task/all".format(house_1), headers={"Authorization": auth}
     ).get_json()


### PR DESCRIPTION
The endpoint `house/user` only returned the house IDs the user was into. Now it returns `id`, `name`, `description`, `tasks IDs` and `users IDs` for each house.


Fixes #40.